### PR TITLE
Http does not return a Response obj when an Error occurs

### DIFF
--- a/dashboard/src/main/webapp/app/entities/task/task-dialog.component.ts
+++ b/dashboard/src/main/webapp/app/entities/task/task-dialog.component.ts
@@ -74,14 +74,14 @@ export class TaskDialogComponent implements OnInit {
         this.activeModal.dismiss('cancel');
     }
 
-    save () {
+    save() {
         this.isSaving = true;
         if (this.task.id !== undefined) {
             this.taskService.update(this.task)
-                .subscribe((res: Task) => this.onSaveSuccess(res), (res: Response) => this.onSaveError(res.json()));
+                .subscribe((res: Task) => this.onSaveSuccess(res), (res: Response) => this.onSaveError(res));
         } else {
             this.taskService.create(this.task)
-                .subscribe((res: Task) => this.onSaveSuccess(res), (res: Response) => this.onSaveError(res.json()));
+                .subscribe((res: Task) => this.onSaveSuccess(res), (res: Response) => this.onSaveError(res));
         }
     }
 

--- a/dashboard/src/main/webapp/app/entities/task/task-dialog.component.ts
+++ b/dashboard/src/main/webapp/app/entities/task/task-dialog.component.ts
@@ -78,10 +78,10 @@ export class TaskDialogComponent implements OnInit {
         this.isSaving = true;
         if (this.task.id !== undefined) {
             this.taskService.update(this.task)
-                .subscribe((res: Task) => this.onSaveSuccess(res), (res: Response) => this.onSaveError(res));
+                .subscribe((res: Task) => this.onSaveSuccess(res), (err: Error) => this.onSaveError(err));
         } else {
             this.taskService.create(this.task)
-                .subscribe((res: Task) => this.onSaveSuccess(res), (res: Response) => this.onSaveError(res));
+                .subscribe((res: Task) => this.onSaveSuccess(res), (err: Error) => this.onSaveError(err));
         }
     }
 

--- a/dashboard/src/main/webapp/app/entities/task/task.service.ts
+++ b/dashboard/src/main/webapp/app/entities/task/task.service.ts
@@ -12,28 +12,27 @@ export class TaskService {
 
     create(task: Task): Observable<Task> {
         let copy: Task = Object.assign({}, task);
-        return this.http.post(this.resourceUrl, copy).map((res: Response) => {
-            return res.json();
-        });
+        return this.http.post(this.resourceUrl, copy)
+            .map((res: Response) => res.json())
+            .catch(err => Observable.throw(err));
     }
 
     update(task: Task): Observable<Task> {
         let copy: Task = Object.assign({}, task);
-        return this.http.put(this.resourceUrl, copy).map((res: Response) => {
-            return res.json();
-        });
+        return this.http.put(this.resourceUrl, copy)
+            .map((res: Response) => res.json())
+            .catch(err => Observable.throw(err));
     }
 
     find(id: number): Observable<Task> {
-        return this.http.get(`${this.resourceUrl}/${id}`).map((res: Response) => {
-            return res.json();
-        });
+        return this.http.get(`${this.resourceUrl}/${id}`)
+            .map((res: Response) => res.json())
+            .catch(err => Observable.throw(err));
     }
 
     query(req?: any): Observable<Response> {
         let options = this.createRequestOption(req);
-        return this.http.get(this.resourceUrl, options)
-        ;
+        return this.http.get(this.resourceUrl, options);
     }
 
     delete(id: number): Observable<Response> {


### PR DESCRIPTION
Angular `HttpService` does not return a `Response` object when an Http error occurs. That means that the `.json()` method on a `Response` will fail on an error handler.

When an error occurs, you need to rethrow it wrapped in an Observable (or perhaps do something with it).

This will probably not fix the `Http Error 400: Bad Request` errors, but it will at least make the errors legible.